### PR TITLE
add admin to users

### DIFF
--- a/db/migrate/20240514182642_add_admin_to_users.rb
+++ b/db/migrate/20240514182642_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_160024) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_182642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,8 +56,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_160024) do
   end
 
   create_table "leisures", force: :cascade do |t|
-    t.integer "category_id", null: false
-    t.integer "venue_id", null: false
+    t.bigint "category_id", null: false
+    t.bigint "venue_id", null: false
     t.string "picture"
     t.string "link"
     t.string "title"
@@ -78,8 +78,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_160024) do
   end
 
   create_table "leisures_genres", force: :cascade do |t|
-    t.integer "leisure_id", null: false
-    t.integer "genre_id", null: false
+    t.bigint "leisure_id", null: false
+    t.bigint "genre_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["genre_id"], name: "index_leisures_genres_on_genre_id"
@@ -94,6 +94,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_160024) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Hi, Carla! 

- I did a bundle install because of the new gems, and had to db:create before migrating. 

- Then I generated a migration to add admin to users and db:migrated.

- I signed up from the sign up page, and checked in the console, the admin boolean is set as nil in the newly created user. I expected it to be false... Is it ok this way?
