### PR TITLE
Fix formatting in leisure event views by correcting the duration disp…

### DIFF
--- a/app/views/shared/_danca.html.erb
+++ b/app/views/shared/_danca.html.erb
@@ -14,7 +14,7 @@
             <% names << genre.name %>
           <% end %>
           <%= names.join(" / ") %>
-        | <%= leisure.director %>  | <%= leisure.duration %> |
+        | <%= leisure.director %>  | <%= leisure.duration %>' |
         <%if leisure.min_age == 0 %>
           L
         <% elsif leisure.min_age.nil? %>

--- a/app/views/shared/_teatro.html.erb
+++ b/app/views/shared/_teatro.html.erb
@@ -20,7 +20,7 @@
         <% else %>
           <%= leisure.min_age.to_s %>
         <% end %>
-        | <%= leisure.duration %> </em></p>
+        | <%= leisure.duration %>' </em></p>
       <p id="horario">
         <i class="fa-regular fa-calendar"></i> <%= leisure.schedule %> | <%= leisure.date %>
       </p>


### PR DESCRIPTION
…lay to include a trailing apostrophe. This ensures consistency in the presentation of event details across the danca and teatro views.