### PR TITLE
Add hide_date feature to leisure events

### DIFF
--- a/app/controllers/leisures_controller.rb
+++ b/app/controllers/leisures_controller.rb
@@ -471,7 +471,7 @@ class LeisuresController < ApplicationController
   end
 
   def leisure_params
-    params.require(:leisure).permit(:category_id, :subcategory_id, :photo, :link, :title, :subtitle, :director, :country, :description, :schedule, :features, :min_age, :duration, :time, :start_date, :end_date, :publish_date, :hidden, :free, :price, :date, :alt_text, dates: [])
+    params.require(:leisure).permit(:category_id, :subcategory_id, :photo, :link, :title, :subtitle, :director, :country, :description, :schedule, :features, :min_age, :duration, :time, :start_date, :end_date, :publish_date, :hidden, :free, :price, :date, :alt_text, :hide_date, dates: [])
   end
 
   def set_leisure

--- a/app/models/leisure.rb
+++ b/app/models/leisure.rb
@@ -36,6 +36,4 @@ class Leisure < ApplicationRecord
   def dates=(dates_array)
     write_attribute(:dates, dates_array)
   end
-
-
 end

--- a/app/views/leisures/edit.html.erb
+++ b/app/views/leisures/edit.html.erb
@@ -53,6 +53,13 @@
 
         <%= f.input :hidden, label: 'Oculto',label_html: { class: 'fw-bold' } %>
 
+        <div class="row">
+          <div class="col-lg-6 col-12">
+            <%= f.input :hide_date, label: 'Data para ocultar automaticamente:', label_html: { class: 'fw-bold' }, input_html: { class: 'form-control' } %>
+            <small class="form-text text-muted">Quando esta data chegar, o evento será automaticamente ocultado</small>
+          </div>
+        </div>
+
           <div class="row">
             <div class="col-lg-6 col-12">
               <%= f.association :venues,  label: 'Estabelecimento*(OBRIGATÓRIO):', label_html: { class: 'fw-bold text-danger' }, input_html: {multiple: true, required: true,

--- a/app/views/leisures/new.html.erb
+++ b/app/views/leisures/new.html.erb
@@ -65,6 +65,13 @@
 
         <%= f.input :hidden, label: 'Oculto',label_html: { class: 'fw-bold' } %>
 
+        <div class="row">
+          <div class="col-lg-6 col-12">
+            <%= f.input :hide_date, label: 'Data para ocultar automaticamente:', label_html: { class: 'fw-bold' }, input_html: { class: 'form-control' } %>
+            <small class="form-text text-muted">Quando esta data chegar, o evento será automaticamente ocultado</small>
+          </div>
+        </div>
+
           <div class="row">
             <div class="col-lg-6 col-12">
               <%= f.association :venues,  label: 'Estabelecimento*(OBRIGATÓRIO):', label_html: { class: 'fw-bold text-danger' }, input_html: {multiple: true, required: true,

--- a/db/migrate/20250911041444_add_hide_date_to_leisures.rb
+++ b/db/migrate/20250911041444_add_hide_date_to_leisures.rb
@@ -1,0 +1,5 @@
+class AddHideDateToLeisures < ActiveRecord::Migration[7.1]
+  def change
+    add_column :leisures, :hide_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_29_040429) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_11_041444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -134,6 +134,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_29_040429) do
     t.jsonb "dates", default: []
     t.string "alt_text"
     t.decimal "price", precision: 8, scale: 2
+    t.date "hide_date"
     t.index ["category_id"], name: "index_leisures_on_category_id"
     t.index ["user_id"], name: "index_leisures_on_user_id"
   end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,8 +1,15 @@
 desc "LeisureCleanup is called by the Heroku scheduler add-on"
 task :clean_leisures => :environment do
   today = Date.today
-  puts "apagando eventos expirados..."
+  
+  puts "ocultando eventos com hide_date expirado..."
+  hidden_count = Leisure.where('hide_date <= ? AND hidden = ?', today, false).update_all(hidden: true)
+  puts "ocultados #{hidden_count} eventos"
+  
+  puts "apagando eventos com end_date expirado..."
+  deleted_count = Leisure.where('end_date <= ?', today).count
   Leisure.where('end_date <= ?', today).destroy_all
+  puts "deletados #{deleted_count} eventos"
+  
   puts "prontinho!"
-
 end


### PR DESCRIPTION
This commit introduces a new field 'hide_date' to the leisure model, allowing events to be automatically hidden after a specified date. The leisure_params method has been updated to permit this new attribute. Additionally, the edit and new views have been modified to include an input for 'hide_date', enhancing the user interface. The scheduler task has also been updated to hide events with an expired hide_date, improving event management.