### PR TITLE
Implement price formatting helper for leisure events

### DIFF
--- a/app/helpers/leisures_helper.rb
+++ b/app/helpers/leisures_helper.rb
@@ -2,5 +2,16 @@ module LeisuresHelper
   def partial_select(leisure)
     "shared/#{leisure.category.name.downcase}"
   end
+
+  def format_price(price)
+    # Check if the price has decimal places that are not zero
+    if price % 1 == 0
+      # No decimal places needed
+      number_with_precision(price, precision: 0, separator: ',', delimiter: '.')
+    else
+      # Show decimal places
+      number_with_precision(price, precision: 2, separator: ',', delimiter: '.')
+    end
+  end
 end
 

--- a/app/views/shared/_danca.html.erb
+++ b/app/views/shared/_danca.html.erb
@@ -28,7 +28,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>  
       <% if leisure.free? %>

--- a/app/views/shared/_evento.html.erb
+++ b/app/views/shared/_evento.html.erb
@@ -12,7 +12,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>

--- a/app/views/shared/_expo.html.erb
+++ b/app/views/shared/_expo.html.erb
@@ -12,7 +12,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>

--- a/app/views/shared/_filme.html.erb
+++ b/app/views/shared/_filme.html.erb
@@ -26,7 +26,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>

--- a/app/views/shared/_mais.html.erb
+++ b/app/views/shared/_mais.html.erb
@@ -12,7 +12,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>

--- a/app/views/shared/_musica.html.erb
+++ b/app/views/shared/_musica.html.erb
@@ -12,7 +12,7 @@
       </p>
       <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>

--- a/app/views/shared/_teatro.html.erb
+++ b/app/views/shared/_teatro.html.erb
@@ -26,7 +26,7 @@
       </p>
         <% if leisure.price.present? && !leisure.free? %>
         <p class="real"><i class="fa-solid fa-ticket fa-rotate-by" style="color: #080a0c; --fa-rotate-angle: 45deg;"></i> 
-          A partir de R$ <%= number_with_precision(leisure.price, precision: 0, separator: ',', delimiter: '.') %>
+          A partir de R$ <%= format_price(leisure.price) %>
         </p>
       <% end %>
       <% if leisure.free? %>


### PR DESCRIPTION
This commit introduces a new helper method `format_price` in the LeisuresHelper module to standardize the display of prices across various leisure event views. The method formats prices to show no decimal places for whole numbers and two decimal places for fractional values. All relevant views have been updated to utilize this new method, enhancing consistency in price presentation.